### PR TITLE
空のチャット送信の禁止

### DIFF
--- a/src/main/resources/templates/chat_page.html
+++ b/src/main/resources/templates/chat_page.html
@@ -73,6 +73,9 @@
         let formData = new FormData();
 
         let chatData = document.getElementById("chat_data").value;
+        if (chatData == "") {
+          return;
+        }
         let receiver = document.getElementById("receiver_input").value;
 
         formData.append("chat_data",chatData);


### PR DESCRIPTION
テキストエリアが空だと送信ボタンを押しても反応しない。